### PR TITLE
Store the kubeconfig on the master as well.

### DIFF
--- a/phase1/gce/configure-vm.sh
+++ b/phase1/gce/configure-vm.sh
@@ -31,6 +31,8 @@ case "${ROLE}" in
       > /srv/kubernetes/apiserver.pem
     get_metadata "k8s-apisever-private-key" \
       > /srv/kubernetes/apiserver-key.pem
+    get_metadata "k8s-master-kubeconfig" \
+      > /srv/kubernetes/kubeconfig.json
     ;;
   "node")
     get_metadata "k8s-node-kubeconfig" \

--- a/phase1/gce/gce.jsonnet
+++ b/phase1/gce/gce.jsonnet
@@ -122,6 +122,7 @@ function(cfg)
             "k8s-ca-public-key": "${tls_self_signed_cert.root.cert_pem}",
             "k8s-apisever-public-key": "${tls_locally_signed_cert.master.cert_pem}",
             "k8s-apisever-private-key": "${tls_private_key.master.private_key_pem}",
+            "k8s-master-kubeconfig": kubeconfig("master"),
           },
           disk: [{
             image: gce.os_image,


### PR DESCRIPTION
Some kube components such as kube-proxy that run as daemon set
run on master as well and they need kubeconfig to contact the
API server, so we need to store the kubeconfig on the master
as well.
