### PR TITLE
Fix race condition when waiting for kubeconfig.

### DIFF
--- a/phase1/gce/do
+++ b/phase1/gce/do
@@ -45,7 +45,13 @@ fetch_kubeconfig() {
   for tries in {1..60}; do
     echo Trying to fetch kubeconfig from master... $tries/60
 
-    if gcloud compute ssh --project "$PROJECT" --zone "$ZONE" "$MASTER" --command "sudo cat /etc/kubernetes/admin.conf" > .tmp/kubeconfig.json; then
+    # We can't use copy-files here because only root can read the file
+    # (intentionally). However, if the very first invocation of this command
+    # succeeds, then stdout is tainted by ssh initialization output, so we echo
+    # a marker to indicate the start of the file, and delete all lines up to and
+    # including it.
+    if gcloud compute ssh --project "$PROJECT" --zone "$ZONE" "$MASTER" --command "echo STARTFILE; sudo cat /etc/kubernetes/admin.conf" > .tmp/kubeconfig.raw; then
+      sed '1,/^STARTFILE$/d' .tmp/kubeconfig.raw > .tmp/kubeconfig.json
       echo Successfully fetched kubeconfig.
       return
     else


### PR DESCRIPTION
If `WAIT_FOR_KUBECONFIG` is set and the cluster comes up very quickly so that first ssh call succeeds, then the output from ssh's initialization (generating keys, showing fingerprints/randomart, etc.) can get included at the start of the `kubeconfig.json` file, rendering it invalid.

To alleviate this, echo a marker to indicate the start of the file so we can delete this noise.

CC @mikedanese 