### PR TITLE
Updating vsphere kubernetes cluster deployment flow

### DIFF
--- a/phase1/Kconfig
+++ b/phase1/Kconfig
@@ -9,7 +9,7 @@ config phase1.num_nodes
 	  The number of nodes you would like to provision.
 
 config phase1.cluster_name
-	string "cluster name"
+	string "kubernetes cluster name"
 	default "kubernetes"
 	help
 	  An identifier to use for this cluster.

--- a/phase1/vsphere/Kconfig
+++ b/phase1/vsphere/Kconfig
@@ -39,18 +39,47 @@ config phase1.vSphere.datastore
 	help
 		The datastore where VMs will be created. This will also be used for provisioning volumes for storage classes.
 
-config phase1.vSphere.resourcepool
-        string "Specify a valid Cluster, Host or Resource Pool in which to deploy Kubernetes VMs."
+config phase1.vSphere.placement
+	string "Deploy Kubernetes Cluster on 'host' or 'cluster'"
+	default "cluster"
+	help
+		Select Where to deploy Kubernetes Cluster. On specific host or cluster
+
+if phase1.vSphere.placement = "host"
+	config phase1.vSphere.host
+        string "host"
         default ""
         help
-		Specify a valid Cluster, Host or Resource Pool in which to deploy Kubernetes VMs.
+			Host where kubernetes cluster will be created.
+endif
+
+if phase1.vSphere.placement = "cluster"
+	config phase1.vSphere.cluster
+        string "vspherecluster"
+        default ""
+        help
+			vSphere cluster where kubernetes cluster will be created.
+endif
+
+config phase1.vSphere.useresourcepool
+	string "Do you want to use the resource pool created on the host or cluster? [yes, no]"
+	default "no"
+	help
+		Deploy cluster on Resource Pool? Enter yes or no
+
+if phase1.vSphere.useresourcepool = "yes"
+	config phase1.vSphere.resourcepool
+        string "Name of the Resource Pool. If Resource pool is enclosed within another Resource pool, specify pool hierarchy as ParentResourcePool/ChildResourcePool"
+        default ""
+        help
+			Resource Pool where kubernetes cluster will be deployed.
+endif
 
 config phase1.vSphere.vcpu
 	int "Number of vCPUs for each VM"
 	default 1
 	help
 		Number of vcpu required for VM.
-
 
 config phase1.vSphere.memory
 	int "Memory for VM"
@@ -65,7 +94,7 @@ config phase1.vSphere.network
 		Network to use for each VM.
 
 config phase1.vSphere.template
-	string "Name of the template VM imported from OVA"
+	string "Name of the template VM imported from OVA. If Template file is not available at the destination location specify vm path"
 	default "KubernetesAnywhereTemplatePhotonOS.ova"
 	help
 		Template to clone VMs from.

--- a/phase1/vsphere/vSphere.jsonnet
+++ b/phase1/vsphere/vSphere.jsonnet
@@ -102,8 +102,14 @@ function(config)
             memory: cfg.vSphere.memory,
             enable_disk_uuid: true,
             datacenter: cfg.vSphere.datacenter,
-            resource_pool: cfg.vSphere.resourcepool,
-	    skip_customization: true,
+            skip_customization: true,
+            resource_pool: (
+              if cfg.vSphere.useresourcepool == "no" then
+                if cfg.vSphere.placement == "host" then cfg.vSphere.host
+                else cfg.vSphere.cluster
+              else
+                if cfg.vSphere.placement == "host" then std.join("/", ["/", cfg.vSphere.datacenter, "host", cfg.vSphere.host, "Resources", cfg.vSphere.resourcepool])
+                else std.join("/", ["/", cfg.vSphere.datacenter, "host", cfg.vSphere.cluster, "Resources", cfg.vSphere.resourcepool])),
             folder: "${vsphere_folder.cluster_folder.path}",
             network_interface: {
               label: cfg.vSphere.network,


### PR DESCRIPTION
Current Menu is asking user to specify a cluster, host or a resource pool in which he wants to deploy Kubernetes Cluster. 

`Specify a valid Cluster, Host or Resource Pool in which to deploy Kubernetes VMs. (phase1.vSphere.resourcepool) [] (NEW)`

We have documented how the resource pool path looks like, but it is inconvenient to read up documentation, and build the path. We should change the Menu options to build up resource pool path for user. User just need to  enter the resource pool name.

Following is the change we want in the Menu options.

```
Deploy Kubernetes Cluster on 'host' or 'cluster' (phase1.vSphere.placement) [cluster] (NEW) cluster
    vspherecluster (phase1.vSphere.cluster) [] (NEW) cluster-vsan-1
Do you want to use resource pool created on host or cluster? [yes, no] (phase1.vSphere.useresourcepool) [no] (NEW) yes
    name of the resource pool [Provide Just a name] (phase1.vSphere.resourcepool) [] (NEW) dbResourcePool
```
Verified change with deploying cluster on the resource pool created in host and in cluster.

@msterin @BaluDontu @pdhamdhere @tusharnt

