### PR TITLE
Correcting release file to download and unzip

### DIFF
--- a/phase1/vsphere/README.md
+++ b/phase1/vsphere/README.md
@@ -79,7 +79,7 @@ echo -n > /etc/machine-id
 ### Download `kubernetes-anywhere`:
 
 ```shell
-curl -sL https://github.com/kubernetes/kubernetes-anywhere/archive/v0.1.0.zip | tar xz
+curl -sL https://github.com/kubernetes/kubernetes-anywhere/archive/v0.1.0.tar.gz | tar xz
 cd kubernetes-anywhere-0.1.0
 ```
 


### PR DESCRIPTION
Observed issue while downloading and unzipping kubernetes-anywhere release build.
Note: This issue is not observed on Mac OS X, on linux and windows this issue is re-producible.

```
$ curl -sL https://github.com/kubernetes/kubernetes-anywhere/archive/v0.1.0.zip | tar xz
gzip: stdin has more than one entry--rest ignored
tar: Child died with signal 13
tar: Error is not recoverable: exiting now
```

PR is correcting link to download so that It can be unzipped without this issue.
@abrarshivani @msterin @BaluDontu @tusharnt
