### PR TITLE
UX improvements while deploying k8s on vsphere 

### DIFF
--- a/phase1/vsphere/Kconfig
+++ b/phase1/vsphere/Kconfig
@@ -55,28 +55,28 @@ endif
 
 if phase1.vSphere.placement = "cluster"
 	config phase1.vSphere.cluster
-        string "vspherecluster"
+        string "vsphere cluster name. Please make sure that all the hosts in the cluster are time-synchronized otherwise some of the nodes can remain in pending state for ever due to expired certificate"
         default ""
         help
 			vSphere cluster where kubernetes cluster will be created.
 endif
 
 config phase1.vSphere.useresourcepool
-	string "Do you want to use the resource pool created on the host or cluster? [yes, no]"
+	string "Do you want to use the existing resource pool on the host or cluster? [yes, no]"
 	default "no"
 	help
-		Deploy cluster on Resource Pool? Enter yes or no
+		Deploy cluster on existing Resource Pool? Enter yes or no
 
 if phase1.vSphere.useresourcepool = "yes"
 	config phase1.vSphere.resourcepool
-        string "Name of the Resource Pool. If Resource pool is enclosed within another Resource pool, specify pool hierarchy as ParentResourcePool/ChildResourcePool"
+        string "Name of the existing Resource Pool. If Resource pool is enclosed within another Resource pool, specify pool hierarchy as ParentResourcePool/ChildResourcePool"
         default ""
         help
-			Resource Pool where kubernetes cluster will be deployed.
+			Existing Resource Pool where kubernetes cluster will be deployed.
 endif
 
 config phase1.vSphere.vmfolderpath
-	string "VM Folder name or Path (e.g kubernetes, VMFolder1/dev-cluster, VMFolder1/Test Group1/test-cluster)"
+	string "VM Folder name or Path (e.g kubernetes, VMFolder1/dev-cluster, VMFolder1/Test Group1/test-cluster). Folder path will be created if not present"
 	default "kubernetes"
 	help
 		VM Folder Path where Node VMs should be placed.

--- a/phase3/all.jsonnet
+++ b/phase3/all.jsonnet
@@ -1,5 +1,5 @@
 function(cfg)
-  local if_enabled(addon, manifest) = if std.objectHas(cfg.phase3, addon) && cfg.phase3[addon] then manifest else {};
+  local if_enabled(addon, manifest) = if std.objectHas(cfg, "phase3") && std.objectHas(cfg.phase3, addon) && cfg.phase3[addon] then manifest else {};
   local join(arr) = std.foldl(function(a, b) a + b, arr, {});
   if_enabled("run_addons",
              join([

--- a/phase3/do
+++ b/phase3/do
@@ -18,7 +18,7 @@ gen() {
 deploy() {
 	gen
 	mkdir -p /tmp/kubectl/
-	HOME=/tmp/kubectl kubectl apply -f ./${TMP_DIR}
+	HOME=/tmp/kubectl kubectl apply -f ${TMP_DIR}
 }
 
 

--- a/util/validate
+++ b/util/validate
@@ -13,7 +13,7 @@ num_nodes="$(( $(cat ${CONFIG_FILE} | jq -r '.phase1.num_nodes') + 1 ))"
 while true; do
   total_time=$(( ${total_time} + ${wait_duration} ))
   hcount=$(kubectl get nodes 2>/dev/null | grep 'Ready' | wc -l) || true
-  echo "Validation: Expected ${num_nodes} healthy nodes; found ${hcount}. (${total_time}s elapsed)"
+  echo "Validation: Expected ${num_nodes} (workers + master) healthy nodes; found ${hcount}. (${total_time}s elapsed)"
 
   [[ "${hcount}" -ge "${num_nodes}" ]] && echo "Validation: Success!" && exit
 


### PR DESCRIPTION
Few UX issues are mentioned @ https://github.com/vmware/kubernetes/issues/249

Below issues addressed:

1. Where ever vCenter Inventory Resource is automatically created by Kubernetes-Anywhere (For example Folder) specify in the prompt, that object will be created if not present in the inventory. And for objects which needs to be present and kubernetes-anywhere can not create, specify in the user prompt with text - "Existing", so user knows that this object should be already present in the inventory. (For example Resource Pool, which can not be created by Kubernetes-Anywhere)

2. Put a note that all ESX host should have time in sync, else some of the node can remain in pending state for ever due to certificate expired certificate. Node VM inherits time from the esx host.

3. At present node VMs has sequence node1, node2 ..., instead append some unique char sequence, so that multiple clusters can be deployed in the same working directory folder. with this change <k8s-cluster-name>-master, <k8s-cluster-name>-node1 .... VM names will be used.

4. When user specifies that he wants to deploy 4 node cluster, in the end Kubernetes-Anywhere is waiting for 5 nodes to become healthy. This is because 5th node is the master node, specify this in the message so that user does not get confused.

This also fixes https://github.com/kubernetes/kubernetes-anywhere/issues/375

@divyenpatel, @BaluDontu, @tusharnt, @luomiao 
