### PR TITLE
Move docker_registry back to required Kconfig vars

### DIFF
--- a/phase2/Kconfig
+++ b/phase2/Kconfig
@@ -7,6 +7,12 @@ config phase2.kubernetes_version
 	help
 	  The version of Kubernetes to deploy to the control plane.
 
+config phase2.docker_registry
+	string "docker registry"
+	default "gcr.io/google-containers"
+	help
+	  The docker registry to pull cluster components from.
+
 config phase2.provider
 	string "bootstrap provider"
 	default "ignition"
@@ -20,12 +26,6 @@ if phase2.provider = ignition
 config phase2.installer_container
 	string "installer container"
 	default "docker.io/cnastorage/k8s-ignition:v2"
-
-config phase2.docker_registry
-	string "docker registry"
-	default "gcr.io/google-containers"
-	help
-	  The docker registry to pull cluster components from.
 
 endif
 


### PR DESCRIPTION
docker_registry is used in phase3 for deploying addons and other
components that do not hardcode a registry.