### PR TITLE
Set `--discovery-token-unsafe-skip-ca-verification` flag when `--discovery-token-ca-cert-hash` is not set

### DIFF
--- a/phase2/kubeadm/configure-vm-kubeadm-node.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm-node.sh
@@ -1,4 +1,4 @@
 
 # This is not meant to run on its own, but extends phase2/kubeadm/configure-vm-kubeadm.sh
 
-kubeadm join --token "$KUBEADM_TOKEN" "$KUBEADM_MASTER_IP:443" --skip-preflight-checks
+kubeadm join --token "$KUBEADM_TOKEN" "$KUBEADM_MASTER_IP:443" --skip-preflight-checks --discovery-token-unsafe-skip-ca-verification true


### PR DESCRIPTION
ref: https://github.com/kubernetes/kubeadm/issues/534 https://github.com/kubernetes/kubernetes/pull/54982

/cc @luxas 