### PR TITLE
Fix passing flag --discovery-token-unsafe-skip-ca-verification to kubeadm join

### DIFF
--- a/phase2/kubeadm/configure-vm-kubeadm-node.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm-node.sh
@@ -1,4 +1,10 @@
 
 # This is not meant to run on its own, but extends phase2/kubeadm/configure-vm-kubeadm.sh
 
-kubeadm join --token "$KUBEADM_TOKEN" "$KUBEADM_MASTER_IP:443" --skip-preflight-checks --discovery-token-unsafe-skip-ca-verification true
+OPTS=""
+if [[ $KUBEADM_VERSION == "stable" ]] || [[ $(semver_compare $KUBEADM_VERSION "v1.8.0") -gt 1 ]]; then
+  # `--discovery-token-unsafe-skip-ca-verification` flag is only supported from kubeadm version 1.8.0 onwards
+  OPTS="--discovery-token-unsafe-skip-ca-verification"
+fi
+
+kubeadm join --token "$KUBEADM_TOKEN" "$KUBEADM_MASTER_IP:443" --skip-preflight-checks $OPTS

--- a/phase2/kubeadm/configure-vm-kubeadm.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm.sh
@@ -1,6 +1,49 @@
 
 # This is not meant to run on its own, but extends phase1/<CLOUD_PROVIDER>/configure-vm.sh
 
+# $1 - VER_A
+# $2 - VER_B
+# echo 0 - Either VER_A or VER_B does not match the regular expression
+# echo 1 - VER_A -lt VER_B
+# echo 2 - VER_A -eq VER_B
+# echo 3 - VER_A -gt VER_B
+semver_compare(){
+  local RE='.*v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*).*'
+
+  if [[ "$1" =~ $RE ]] && [[ "$2" =~ $RE ]]; then
+    : #$1 & $2 are REs
+  else
+    echo 0
+  fi
+
+  MAJOR_A=$(echo $1 | sed -r -e "s#$RE#\1#")
+  MAJOR_B=$(echo $2 | sed -r -e "s#$RE#\1#")
+  MINOR_A=$(echo $1 | sed -r -e "s#$RE#\2#")
+  MINOR_B=$(echo $2 | sed -r -e "s#$RE#\2#")
+  PATCH_A=$(echo $1 | sed -r -e "s#$RE#\3#")
+  PATCH_B=$(echo $2 | sed -r -e "s#$RE#\3#")
+
+  if [[ $MAJOR_A -lt $MAJOR_B ]]; then
+    echo 1
+  elif [[ $MAJOR_A -gt $MAJOR_B ]]; then
+    echo 3
+  else
+    if [[ $MINOR_A -lt $MINOR_B ]]; then
+      echo 1
+    elif [[ $MINOR_A -gt $MINOR_B ]]; then
+      echo 3
+    else
+      if [[ $PATCH_A -lt $PATCH_B ]]; then
+        echo 1
+      elif [[ $PATCH_A -gt $PATCH_B ]]; then
+        echo 3
+      else
+        echo 2
+      fi
+    fi
+  fi
+}
+
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 
 if [[ "$KUBEADM_KUBELET_VERSION" == stable ]]; then


### PR DESCRIPTION
Address the comment in https://github.com/kubernetes/kubernetes-anywhere/pull/488/files#r153078767

I have tested the changes in my local gce environment and it has passed for `"$KUBEADM_VERSION" == "stable"`

/cc @xiangpengzhao @luxas @pipejakob 