### PR TITLE
Kubeadm installs fail with removal of kubelet and kubeadm

### DIFF
--- a/phase2/kubeadm/configure-vm-kubeadm.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm.sh
@@ -60,6 +60,9 @@ elif [[ "$KUBEADM_KUBELET_VERSION" == "gs://"* ]]; then
   gsutil rsync "$KUBEADM_KUBELET_VERSION" $TMPDIR
   # kubeadm is installed with the kubelet so that the
   # kubelet has the configuration at a matching version
+  # TODO: Remove the following mkdir when bazelbuild/bazel
+  # issue #4651 gets resolved.
+  mkdir -p /opt/cni/bin
   dpkg -i $TMPDIR/{kubelet,kubeadm,kubectl,kubernetes-cni}.deb || echo Ignoring expected dpkg failure
   apt-get install -f -y
   systemctl enable kubelet


### PR DESCRIPTION
## Problem Description:
Kubeadm installations are failing on the master node. Looking at
startup logs on the master node:

```
Jan 23 01:56:33 e2e-9c7300d2ef-master startup-script[1785]: INFO startup-script: dpkg: error processing archive /tmp/k8s-debs/kubernetes-cni.deb (--install):
Jan 23 01:56:33 e2e-9c7300d2ef-master startup-script[1785]: INFO startup-script:  error creating directory '/opt/cni/bin': No such file or directory
Jan 23 01:56:33 e2e-9c7300d2ef-master startup-script[1785]: INFO startup-script: dpkg-deb: error: subprocess paste was killed by signal (Broken pipe)
Jan 23 01:56:33 e2e-9c7300d2ef-master startup-script[1785]: INFO startup-script: dpkg: dependency problems prevent configuration of kubelet:
Jan 23 01:56:33 e2e-9c7300d2ef-master startup-script[1785]: INFO startup-script:  kubelet depends on kubernetes-cni (>= 0.5.1); however:
Jan 23 01:56:33 e2e-9c7300d2ef-master startup-script[1785]: INFO startup-script:   Package kubernetes-cni is not installed.
```
followed by:
```
Jan 23 01:56:33 e2e-9c7300d2ef-master startup-script[1785]: INFO startup-script:  /tmp/k8s-debs/kubernetes-cni.deb
Jan 23 01:56:33 e2e-9c7300d2ef-master startup-script[1785]: INFO startup-script:  kubelet
Jan 23 01:56:33 e2e-9c7300d2ef-master startup-script[1785]: INFO startup-script:  kubeadm
```
and:
```
Jan 23 01:56:35 e2e-9c7300d2ef-master startup-script[1785]: INFO startup-script: The following packages will be REMOVED:
Jan 23 01:56:35 e2e-9c7300d2ef-master startup-script[1785]: INFO startup-script:   kubeadm kubelet
```

Apparently what's happening is this:
- Startup script tries to install kubernetes-cni, kubelet, and kubeadm from debs packages
- Installation of kubernetes-cni fails because the directory /opt/cni/bin can't be created
- Installation of kubelet fails because it depends upon kubernetes-cni being installed
- Installation of kubeadm fails because it depends upon kubelet being installed
- The 'apt-get install -f -y' cmd detects these dependency failures and remove kubelet and kubeadm
- Because kubeadm is missing, the 'kubeadm init ...' command can't be run, so that the kubeconfig in /etc/kubernetes is never created
- Because the kubeconfig is never created, kubernetes-anywhere fails after 50 (or is it 60, I forget) attempts to read the kubeconfig.

## Fix:
Preemptively adding a creation of a directory /opt/cni/bin before installing
kubernetes-cni fixes the problem.

## Log with Fix Showing Success:
[Successful Log Snippet](https://gist.github.com/leblancd/f596e4b34f4768efa7748d3cca4a062e)

fixes #513 
