### PR TITLE
Fix Flannel network default value as per RFC1918

### DIFF
--- a/phase1/vsphere/Kconfig
+++ b/phase1/vsphere/Kconfig
@@ -107,7 +107,7 @@ config phase1.vSphere.template
 
 config phase1.vSphere.flannel_net
 	string "Flannel Network"
-	default "172.1.0.0/16"
+	default "172.16.0.0/16"
 	help
 		 IP range used for flannel overlay network.
 

--- a/phase1/vsphere/README.md
+++ b/phase1/vsphere/README.md
@@ -213,7 +213,7 @@ cloud provider: gce, azure or vsphere (phase1.cloud_provider) [vsphere] (NEW) vs
 
 * Configure the POD network using flannel
 ```
-  Flannel Network (phase1.vSphere.flannel_net) [172.1.0.0/16] (NEW)
+  Flannel Network (phase1.vSphere.flannel_net) [172.16.0.0/16] (NEW)
 ```
 
 * Ignition image to be used for phase 2.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #497 
| Related issues/PRs | supersedes #516
| License | Apache 2.0
| CLA signed | yes

#### What's in this PR?

Fixes the default value of the vSphere flannel network to 172.16.0.0/16, which is within the private "20-bit block" according to RFC1918.

I assume the 172.1.0.0/16 was solely a typo.