### PR TITLE
Remove the deprecated --skip-preflight-checks for kubeadm

### DIFF
--- a/phase2/kubeadm/configure-vm-kubeadm-master.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm-master.sh
@@ -103,4 +103,4 @@ featureGates:
 EOF
 fi
 
-kubeadm init --skip-preflight-checks --config $KUBEADM_CONFIG_FILE
+kubeadm init --ignore-preflight-errors=all --config $KUBEADM_CONFIG_FILE

--- a/phase2/kubeadm/configure-vm-kubeadm-node.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm-node.sh
@@ -7,4 +7,4 @@ if [[ $KUBEADM_VERSION == "stable" ]] || [[ $(semver_compare $KUBEADM_VERSION "v
   OPTS="--discovery-token-unsafe-skip-ca-verification"
 fi
 
-kubeadm join --token "$KUBEADM_TOKEN" "$KUBEADM_MASTER_IP:443" --skip-preflight-checks $OPTS
+kubeadm join --token "$KUBEADM_TOKEN" "$KUBEADM_MASTER_IP:443" --ignore-preflight-errors=all $OPTS

--- a/phase2/kubeadm/do
+++ b/phase2/kubeadm/do
@@ -22,7 +22,7 @@ upgrade_master() {
 
   case "${UPGRADE_METHOD}" in
     "init")
-      execute_host ${MASTER} "sudo kubeadm init --skip-preflight-checks --config ${KUBEADM_CONFIG_FILE}"
+      execute_host ${MASTER} "sudo kubeadm init --ignore-preflight-errors=all --config ${KUBEADM_CONFIG_FILE}"
       ;;
     "upgrade")
       execute_host ${MASTER} "sudo kubeadm config upload from-file --config ${KUBEADM_CONFIG_FILE}"


### PR DESCRIPTION
Use --ignore-preflight-errors=all instead.

removed in PR:
https://github.com/kubernetes/kubernetes/pull/62727

failing test tracking issue:
https://github.com/kubernetes/kubernetes/issues/66338

i don't have a good solution if someone tries an old kubeadm version with k-a....
this is difficult to maintain.

/assign @luxas 
/cc @timothysc @BenTheElder 
