### PR TITLE
phase1-gce: make it possible to use GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/phase1/gce/do
+++ b/phase1/gce/do
@@ -13,6 +13,12 @@ CLUSTER_NAME=$(jq -r '.phase1.cluster_name' ${CONFIG_FILE})
 CLUSTER_DIR=clusters/${CLUSTER_NAME}
 TMP_DIR=${CLUSTER_DIR}/.tmp
 
+# If 'account.json' is missing, try to use the file defined in 'GOOGLE_APPLICATION_CREDENTIALS'
+if [[ ! -e account.json ]] && [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] &&
+   [[ -e "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
+  ln -s "${GOOGLE_APPLICATION_CREDENTIALS}" account.json
+fi
+
 generate_token() {
   perl -e 'printf "%06x.%08x%08x\n", rand(0xffffff), rand(0xffffffff), rand(0xffffffff);'
 }


### PR DESCRIPTION
In case the user has not created the 'account.json' file,
fallback to using the file defined in GOOGLE_APPLICATION_CREDENTIALS.

If GOOGLE_APPLICATION_CREDENTIALS is not defined or the file there
is missing, do nothing.

fixes https://github.com/kubernetes/kubernetes-anywhere/issues/332
refs: https://github.com/kubernetes/test-infra/pull/9117

i need some feedback on this as have no means to test it ATM. does this look right, GCE wise?
the ideas is to move the following away from the kubeadm test-infra runner and have it in phase1-gce instead:
https://github.com/kubernetes/test-infra/blob/master/images/kubeadm/runner#L32-L36

/assign @mikedanese @errordeveloper 
/cc @BenTheElder
