### PR TITLE
phase2/kubeadm: support "stable*" and "latest*" versions

### DIFF
--- a/phase2/kubeadm/configure-vm-kubeadm-master.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm-master.sh
@@ -23,9 +23,12 @@ mkdir -p $KUBEADM_DIR
 # The raw $KUBEADM_KUBERNETES_VERSION can be passed to the config
 # as kubeadm can handle that.
 KUBEADM_KUBERNETES_SEM_VER=$KUBEADM_KUBERNETES_VERSION
-if [[ $KUBEADM_KUBERNETES_SEM_VER = *"ci/"* ]] ||
-   [[ $KUBEADM_KUBERNETES_SEM_VER = *"ci-cross/"* ]] ||
-   [[ $KUBEADM_KUBERNETES_SEM_VER = *"release/"* ]]; then
+if [[ $KUBEADM_KUBERNETES_SEM_VER = "stable"* ]] ||
+   [[ $KUBEADM_KUBERNETES_SEM_VER = "latest"* ]]; then
+  KUBEADM_KUBERNETES_SEM_VER=`curl -sSL https://dl.k8s.io/release/$KUBEADM_KUBERNETES_SEM_VER.txt`
+elif [[ $KUBEADM_KUBERNETES_SEM_VER = *"ci/"* ]] ||
+     [[ $KUBEADM_KUBERNETES_SEM_VER = *"ci-cross/"* ]] ||
+     [[ $KUBEADM_KUBERNETES_SEM_VER = *"release/"* ]]; then
   KUBEADM_KUBERNETES_SEM_VER=`curl -sSL https://dl.k8s.io/$KUBEADM_KUBERNETES_VERSION.txt`
 fi
 


### PR DESCRIPTION
kuberenetes-anywhere already supports "stable" and "latest" (kubeadm suppots them too), except we now have different
configs for different MINOR versions and we need to parse the SEMVER
to determine what config to use.

Handle these versions in the `-master.sh` script.

kubeadm source code ref:
https://github.com/kubernetes/kubernetes/blob/ed958b7d79ee7eee0d71952e71475fe667c77909/cmd/kubeadm/app/util/version.go#L55-L61

failing e2e job because "stable" is used:
https://github.com/kubernetes/test-infra/blob/82f404e32640453021733e9694a6c5463bb08918/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-x-on-y.yaml#L81-L105

https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-stable-on-master/4722

@kubernetes/sig-cluster-lifecycle-pr-reviews 
/assign @roberthbailey @timothysc 
