### PR TITLE
phase3: download a recent kubectl binary

### DIFF
--- a/phase3/do
+++ b/phase3/do
@@ -20,7 +20,10 @@ gen() {
 deploy() {
 	gen
 	mkdir -p /tmp/kubectl/
-	HOME=/tmp/kubectl kubectl apply -f ${TMP_DIR}
+	export KUBECTL_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/latest.txt)
+	wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /tmp/kubectl/kubectl
+	chmod +x /tmp/kubectl/kubectl
+	HOME=/tmp/kubectl /tmp/kubectl/kubectl apply -f ${TMP_DIR}
 }
 
 


### PR DESCRIPTION
phase3: download a recent kubectl binary

when applying the CNI plugin manifest, kubectl from kubekins is used, which can be quite old.
kubectl 1.10.7 causes a the following failure with recent upstream k8s.
https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-master/1607
```
W0119 19:45:01.703] error: SchemaError(io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfiguration): invalid object doesn't have additional properties
```

download a new kubectl that matches the latest.txt endpoint.

@kubernetes/sig-cluster-lifecycle 
/assign @fabriziopandini @BenTheElder
