### PR TITLE
add the Makefile "setup" rule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM mhart/alpine-node:6.4.0
 RUN apk add --update bash
 ADD ./util/docker-build.sh /opt/
 RUN /opt/docker-build.sh
+ADD ./util/setup-terraform-jsonnet-kubectl.sh /opt/
+RUN /opt/setup-terraform-jsonnet-kubectl.sh
 
 WORKDIR /opt/kubernetes-anywhere
 ADD . /opt/kubernetes-anywhere/

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,10 @@ validate-node-ready: $(CONFIG_JSON_FILE)
 addons: $(CONFIG_JSON_FILE)
 	KUBECONFIG="$$(pwd)/phase1/$(CLOUD_PROVIDER)/$(CLUSTER_DIR)/kubeconfig.json" ./phase3/do deploy
 
+# Optional step to call from e2e jobs. Installs terraform, jsonnet and kubectl
+setup:
+	( cd util/; ./setup-terraform-jsonnet-kubectl.sh )
+
 deploy: | deploy-cluster  validate-cluster-up  addons  validate-node-ready
 destroy: | destroy-cluster
 

--- a/phase3/do
+++ b/phase3/do
@@ -20,10 +20,7 @@ gen() {
 deploy() {
 	gen
 	mkdir -p /tmp/kubectl/
-	export KUBECTL_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/latest.txt)
-	wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /tmp/kubectl/kubectl
-	chmod +x /tmp/kubectl/kubectl
-	HOME=/tmp/kubectl /tmp/kubectl/kubectl apply -f ${TMP_DIR}
+	HOME=/tmp/kubectl /usr/local/bin/kubectl apply -f ${TMP_DIR}
 }
 
 

--- a/util/docker-build.sh
+++ b/util/docker-build.sh
@@ -2,34 +2,12 @@
 
 # WARNING: some of the tools in this build are VERY outdated!
 
-set -eux -o pipefail
+set -o errexit
+set -o pipefail
+set -o nounset
+set -x
 
 apk add --update git build-base wget curl jq autoconf automake pkgconfig ncurses-dev libtool gperf flex bison ca-certificates python openssh-client
-
-## Install kubectl
-export KUBECTL_VERSION=1.11.2
-wget https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl
-chmod +x /usr/local/bin/kubectl
-
-## Install Jsonnet
-cd /tmp
-git clone https://github.com/google/jsonnet.git
-(cd jsonnet
-make jsonnet
-cp jsonnet /usr/local/bin)
-rm -rf /tmp/jsonnet
-
-## Install Terraform
-export TERRAFORM_VERSION=0.9.4
-
-mkdir -p /tmp/terraform/
-(cd /tmp/terraform
-wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
-wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS
-sed -i '/terraform_${TERRAFORM_VERSION}_linux_amd64.zip/!d' /tmp/terraform/terraform_${TERRAFORM_VERSION}_SHA256SUMS
-sha256sum -cs terraform_${TERRAFORM_VERSION}_SHA256SUMS
-unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin)
-rm -rf /tmp/terraform
 
 ## Install kconfig-conf
 export KCONFIG_VERSION=4.7.0.0

--- a/util/setup-terraform-jsonnet-kubectl.sh
+++ b/util/setup-terraform-jsonnet-kubectl.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -x
+
+## Install kubectl
+mkdir -p /tmp/kubectl/
+cd /tmp/kubectl
+export KUBECTL_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/latest.txt)
+wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+cp kubectl /usr/local/bin/kubectl
+chmod +x /usr/local/bin/kubectl
+cd /tmp
+rm -rf /tmp/kubectl
+
+## Install Jsonnet
+cd /tmp
+git clone https://github.com/google/jsonnet.git
+(cd jsonnet
+make jsonnet
+cp jsonnet /usr/local/bin)
+rm -rf /tmp/jsonnet
+
+## Install Terraform
+export TERRAFORM_VERSION=0.9.4
+
+mkdir -p /tmp/terraform/
+(cd /tmp/terraform
+wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS
+sed -i '/terraform_${TERRAFORM_VERSION}_linux_amd64.zip/!d' /tmp/terraform/terraform_${TERRAFORM_VERSION}_SHA256SUMS
+sha256sum -cs terraform_${TERRAFORM_VERSION}_SHA256SUMS
+unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin)
+rm -rf /tmp/terraform


### PR DESCRIPTION
Re-organizes the setup steps:
- Call util/setup...sh when building the local container
- Add a new rule "setup" to call from e2e jobs
- in Phase3 use the kubectl installed from util/setup..sh

This change allows removing the kubeadm image from test-infra.

test-infra PR:
https://github.com/kubernetes/test-infra/pull/10854
