### PR TITLE
util: fix a bug when fetching terraform

### DIFF
--- a/util/setup-terraform-jsonnet-kubectl.sh
+++ b/util/setup-terraform-jsonnet-kubectl.sh
@@ -30,7 +30,7 @@ mkdir -p /tmp/terraform/
 (cd /tmp/terraform
 wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS
-sed -i '/terraform_${TERRAFORM_VERSION}_linux_amd64.zip/!d' /tmp/terraform/terraform_${TERRAFORM_VERSION}_SHA256SUMS
-sha256sum -cs terraform_${TERRAFORM_VERSION}_SHA256SUMS
+sed -i '/linux_amd64/!d' /tmp/terraform/terraform_${TERRAFORM_VERSION}_SHA256SUMS
+sha256sum -c terraform_${TERRAFORM_VERSION}_SHA256SUMS
 unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin)
 rm -rf /tmp/terraform


### PR DESCRIPTION
after the recent switch to the kubekins image from kubeadm image in test-infra
a couple of problems started happening:
- sed does not remove all lines expect the correct line in the list
  of SHAs in the terraform SHA file.
- the sha256sum command in the kubekins image does not have an '-s' option.
  '-c' should suffice.

i didn't have time to check why this SED call suddenly stopped working, but the `-s` problem for sha256sum was obvious in kubeadm-gce-master logs:
https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-master/1663

i've tested the change locally.
